### PR TITLE
Fixed typo in step "And waitrty 3 seconds"

### DIFF
--- a/web_behave/features/dyn_environment_test.feature
+++ b/web_behave/features/dyn_environment_test.feature
@@ -7,7 +7,7 @@ Feature: Tests with the dynamic environment
 
   Actions Before the Feature:
     Given wait 3 seconds
-    And waitrty 3 seconds
+    And wait 3 seconds
     And wait 3 seconds
     And step with a table
       | parameter     | value       |


### PR DESCRIPTION
I supposed that there was a typo in the step "And waitrty 3 seconds" so I changed it to "And wait 3 seconds"